### PR TITLE
Allow ignoring throttle input

### DIFF
--- a/FixCTStart/FixCTStart.cpp
+++ b/FixCTStart/FixCTStart.cpp
@@ -2,19 +2,27 @@
 #include "FixCTStart.h"
 
 
-BAKKESMOD_PLUGIN(FixCTStart, "write a plugin description here", plugin_version, PLUGINTYPE_FREEPLAY)
-
-float steer;
+BAKKESMOD_PLUGIN(FixCTStart, "Fix Custom Training Start", plugin_version, PLUGINTYPE_FREEPLAY);
 
 void FixCTStart::onLoad()
 {
-	// set steer on countdown tick to 0 and then set it back after
+	ignoreSteer = std::make_shared<bool>();
+	ignoreThrottle = std::make_shared<bool>();
+
+	cvarManager->registerCvar("fix_ct_start_steer", "1", "Prevent steer input from starting training", true, true, 0, true, 1)
+		.bindTo(ignoreSteer);
+	cvarManager->registerCvar("fix_ct_start_throttle", "0", "Prevent throttle input from starting training", true, true, 0, true, 1)
+		.bindTo(ignoreThrottle);
+
+	// set steer and throttle on countdown tick to 0 and then set it back after
 	gameWrapper->HookEvent("Function GameEvent_TrainingEditor_TA.Countdown.Tick", [this](std::string eventName) {
 		auto pc = gameWrapper->GetPlayerController();
 		if (!pc) return;
 		auto input = pc.GetVehicleInput();
 		steer = input.Steer;
-		input.Steer = 0.f;
+		throttle = input.Throttle;
+		if (*ignoreSteer) input.Steer = 0.f;
+		if (*ignoreThrottle) input.Throttle = 0.f;
 		pc.SetVehicleInput(input);
 	});
 	gameWrapper->HookEventPost("Function GameEvent_TrainingEditor_TA.Countdown.Tick", [this](std::string eventName) {
@@ -22,8 +30,9 @@ void FixCTStart::onLoad()
 		if (!pc) return;
 		auto input = pc.GetVehicleInput();
 		input.Steer = steer;
+		input.Throttle = throttle;
 		pc.SetVehicleInput(input);
-		});
+	});
 }
 
 void FixCTStart::onUnload()

--- a/FixCTStart/FixCTStart.h
+++ b/FixCTStart/FixCTStart.h
@@ -10,7 +10,12 @@ constexpr auto plugin_version = stringify(VERSION_MAJOR) "." stringify(VERSION_M
 
 class FixCTStart: public BakkesMod::Plugin::BakkesModPlugin/*, public BakkesMod::Plugin::PluginSettingsWindow*//*, public BakkesMod::Plugin::PluginWindow*/
 {
+	float steer;
+	float throttle;
+
+	std::shared_ptr<bool> ignoreSteer;
+	std::shared_ptr<bool> ignoreThrottle;
+
 	virtual void onLoad();
 	virtual void onUnload();
 };
-

--- a/FixCTStart/FixCTStart.vcxproj
+++ b/FixCTStart/FixCTStart.vcxproj
@@ -22,7 +22,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/FixCTStart/version.h
+++ b/FixCTStart/version.h
@@ -1,9 +1,8 @@
 #pragma once
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 0
+#define VERSION_MINOR 1
 #define VERSION_PATCH 0
-#define VERSION_BUILD 3
+#define VERSION_BUILD 1
 
 #define stringify(a) stringify_(a)
 #define stringify_(a) #a
-

--- a/FixCTStart/version.h
+++ b/FixCTStart/version.h
@@ -2,7 +2,7 @@
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
 #define VERSION_PATCH 0
-#define VERSION_BUILD 2
+#define VERSION_BUILD 3
 
 #define stringify(a) stringify_(a)
 #define stringify_(a) #a

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Fix Custom Training Start
+
+Stops custom training shots from beginning when you don't want to.
+
+To disable:\
+F2 -> Plugins -> Plugin Manager -> Open pluginmanager -> untick the FixCTStart plugin
+
+Ignore steer input (set by default):\
+F6 -> Type "fix_ct_start_steer 1" -> Enter
+
+Ignore throttle input (not set by default):\
+F6 -> Type "fix_ct_start_throttle 1" -> Enter
+
+To revert these configuration changes, do the same, but enter "0" instead of "1".


### PR DESCRIPTION
Added a variable to allow ignoring throttle input, too.
It's not breaking current behavior, because it's disabled by default.

---

Why I did this - _feel free to ignore this part_ 😊

Since switching to controller pressing throttle and boost at the same time will result in the throttle input to start before I got the boost button fully pressed. This makes some training packs hard to complete or I have to force myself to press boost before throttle which feels weird.